### PR TITLE
feat: scrub gsap timeline

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -22,6 +22,7 @@
     "gulp-cssnano": "^2.1.1",
     "gulp-expect-file": "0.0.7",
     "gulp-filesize": "0.0.6",
+    "gulp-remove-html": "^1.3.0",
     "gulp-htmlmin": "^3.0.0",
     "gulp-if": "^2.0.0",
     "gulp-imagemin": "^3.1.1",

--- a/generators/app/templates/gulpfile.js/tasks/html.js
+++ b/generators/app/templates/gulpfile.js/tasks/html.js
@@ -6,9 +6,11 @@ var gulp = require('gulp');
 var gulpif = require('gulp-if');
 var htmlmin = require('gulp-htmlmin');
 var uglify = require('gulp-uglify');
+var gulpRemoveHtml = require('gulp-remove-html');
 
 gulp.task('html', function() {
   return gulp.src(config.tasks.html.src)
+    .pipe(gulpif(process.env.NODE_ENV == 'production', gulpRemoveHtml() ))  
     .pipe(gulpif(process.env.NODE_ENV == 'production', htmlmin(config.tasks.html.htmlmin)))
     .pipe(gulp.dest(config.tasks.html.dest))
     .pipe(browserSync.stream());

--- a/generators/app/templates/src/300x250/_index.html
+++ b/generators/app/templates/src/300x250/_index.html
@@ -12,6 +12,9 @@
     <script src="js/banner.js" type="text/javascript"></script>
     <script src="js/banner.loader.js" type="text/javascript"></script>
     <script src="js/banner.animation.js" type="text/javascript"></script>
+    <!--<Deject>-->
+    <script src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/35984/ScrubGSAPTimeline.js" type="text/javascript"></script>
+    <!--</Deject>-->
     <script type="text/javascript">var banner = new Banner();</script><% if (bannerType == 'DCM') { %>
     <script type="text/javascript">var clickTag = "https://www.google.com";</script><% } %>
     <link rel="stylesheet" href="styles/style.css">

--- a/generators/app/templates/src/300x250/js/animation.js
+++ b/generators/app/templates/src/300x250/js/animation.js
@@ -64,5 +64,7 @@ Banner.prototype.animate = function () {
     .addLabel('start', 0)
     .add(TweenLite.to(this.logo, 2, { autoAlpha: 1, scale: 0.7, delay: 1, ease: Elastic.easeOut }))
     .add(TweenLite.to(this.logo, 1, { autoAlpha: 0, scale: 0.4, delay: 1 }));
-
+  
+    // Add timeline to GSAP scrubber. Delete this before running gulp prod.
+    ScrubGSAPTimeline(this.timeline);
 };

--- a/generators/app/templates/src/300x250/styles/base/banner.scss
+++ b/generators/app/templates/src/300x250/styles/base/banner.scss
@@ -1,6 +1,12 @@
 $banner-width: 300px;
 $banner-height: 250px;
 
+body,
+html {
+  width: 100%;
+  height: 100%;
+}
+
 .banner {
   background: #fff;
   cursor: pointer;

--- a/generators/app/templates/src/300x250/styles/base/banner.scss
+++ b/generators/app/templates/src/300x250/styles/base/banner.scss
@@ -1,6 +1,11 @@
 $banner-width: 300px;
 $banner-height: 250px;
 
+*, *:before, *:after {
+  margin: 0;
+  padding: 0;
+}
+
 body,
 html {
   width: 100%;

--- a/generators/app/templates/src/_index.html
+++ b/generators/app/templates/src/_index.html
@@ -46,7 +46,7 @@
       <h1>Optimised for desktop!</h1>
       <img src="base/images/desktop.png" alt="desktop">
     </div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.19.1/TweenMax.min.js"></script>
     <script type="text/javascript" src="base/js/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Added [ScrubGSAPTimeline](https://github.com/chrisgannon/ScrubGSAPTimeline) for timeline scrubbing on mouse move.

The way it works right now that you have to delete one line of code before production as it's not necessary. Additional script that is loaded in head is automatically removed when running gulp prod by gulp-remove-html. 
I couldn't figure how to access timeline from index.html. That way it would be possible to automatically remove that additional line of code as well.